### PR TITLE
出資に制限をかけるメソッドを追加

### DIFF
--- a/app/controllers/investments_controller.rb
+++ b/app/controllers/investments_controller.rb
@@ -1,5 +1,7 @@
 class InvestmentsController < ApplicationController
   before_action :check_owner, only: [:new, :create]
+  before_action :limit_of_amount, only: [:new, :create]
+  before_action :not_exceed_price, only: [:create]
 
   def index
     @investments = current_user.investments.all
@@ -25,6 +27,24 @@ class InvestmentsController < ApplicationController
         return redirect_to product_investments_path, notice: '出資できないよ'
       end
     end
+
+    #出資額の合計を出し、出資に制限をかける
+    def limit_of_amount
+      product = Product.find(params[:product_id])
+      unless Investment.investable?(product)
+        return redirect_to product_investments_path, notice: '目標金額に達したため出資できません！'
+      end
+    end
+
+    #出資金額が希望額を超えないようにする
+    def not_exceed_price
+      product = Product.find(params[:product_id])
+      investment = current_user.investments.new(investment_params)
+      unless investment.exceed?(product)
+        return redirect_to product_investments_path, notice: '目標金額以上の出資はできません！'
+      end
+    end
+
 
     def investment_params
       params.require(:investment).permit(:price)

--- a/app/controllers/investments_controller.rb
+++ b/app/controllers/investments_controller.rb
@@ -39,8 +39,8 @@ class InvestmentsController < ApplicationController
     #出資金額が希望額を超えないようにする
     def not_exceed_price
       product = Product.find(params[:product_id])
-      investment = current_user.investments.new(investment_params)
-      unless investment.exceed?(product)
+      investment = product.investments.new(investment_params)
+      unless investment.exceed?
         return redirect_to product_investments_path, notice: '目標金額以上の出資はできません！'
       end
     end

--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -3,4 +3,15 @@ class Investment < ApplicationRecord
   validates :price, presence: true, numericality: { only_integer: true }
   belongs_to :user
   belongs_to :product
+
+  #目標額と出資額の合計の判別
+  def self.investable?(product)
+    investment_sum_price = product.investments.sum(:price)
+    product.price > investment_sum_price
+  end
+
+  #目標額と出資額の判別
+  def exceed?(product)
+    product.price >= self.price
+  end
 end

--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -11,7 +11,7 @@ class Investment < ApplicationRecord
   end
 
   #目標額と出資額の判別
-  def exceed?(product)
+  def exceed?
     product.price >= self.price
   end
 end

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -7,7 +7,8 @@
     <tr>
       <th>プロダクト名</th>
       <th>プロダクトの説明</th>
-      <th>金額</th>     
+      <th>目標金額</th>
+      <th>達成状況</th>
     </tr>
   </thead>
 
@@ -17,6 +18,7 @@
         <td><%= product.title %></td>
         <td><%= product.desc %></td>
         <td><%= product.price %></td>
+        <td><%= product.investments.sum(:price) %></td>
         <td><%= link_to 'Show', [:admin, product] %></td>
         <td><%= link_to 'Edit', edit_admin_product_path(product) %></td>
         <td><%= link_to 'Destroy', [:admin, product] , method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -11,9 +11,15 @@
 </p>
 
 <p>
-  <strong>金額:</strong>
+  <strong>目標金額:</strong>
   <%= @product.price %>
 </p>
+
+<p>
+  <strong>達成状況:</strong>
+  <%= @product.investments.sum(:price) %>
+</p>
+
 
 <p><strong>いいね数: <%= @product.likes.count %></strong></p>
 

--- a/app/views/investments/index.html.erb
+++ b/app/views/investments/index.html.erb
@@ -7,7 +7,7 @@
     <tr>
       <th>プロダクト名</th>
       <th>企画者</th>
-      <th>金額</th>
+      <th>出資金額</th>
     </tr>
   </thead>
 

--- a/app/views/investments/new.html.erb
+++ b/app/views/investments/new.html.erb
@@ -17,7 +17,7 @@
 </p>
 
 <p>
-  <strong>金額:</strong>
+  <strong>目標金額:</strong>
   <%= @investment.product.price %>
 </p>
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,7 +7,8 @@
     <tr>
       <th>プロダクト名</th>
       <th>プロダクトの説明</th>
-      <th>金額</th>
+      <th>目標金額</th>
+      <th>達成状況</th>
       <th>企画者</th>
     </tr>
   </thead>
@@ -18,6 +19,7 @@
         <td><%= product.title %></td>
         <td><%= product.desc %></td>
         <td><%= product.price %></td>
+        <td><%= product.investments.sum(:price) %></td>
         <td><%= link_to product.user.name, user_path(product.user.id) %>さん</td>
         <td><%= link_to 'Show', product_path(product) %></td>
         <td>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,8 +16,13 @@
 </p>
 
 <p>
-  <strong>金額:</strong>
+  <strong>目標金額:</strong>
   <%= @product.price %>
+</p>
+
+<p>
+  <strong>達成状況:</strong>
+  <%= @product.investments.sum(:price) %>
 </p>
 
 <strong>いいね数: <%= @product.likes.count %></strong>
@@ -28,8 +33,5 @@
 <p>
   <%= link_to '出資する', new_product_investment_path(@product.id) %>
 </p>
-
-
-
 
 <%= link_to 'Back', products_path %>


### PR DESCRIPTION
## Issue

#11

## 内容
InvestmentsコントローラーおよびInvestmentモデルに出資に制限をかけるメソッドを追加しました。


- プロダクトに対して出資された金額の合計を出し、希望額と出資合計額を判別するアクションをlimit_of_amountとする。
	- モデルにクラスメソッドself.investable?を定義。

- 出資対象のプロダクトのセレクトボックスから出資額を選択する際、出資希望額を超えないようにするアクションをnot_exceed_priceとする。
	- モデルにインスタンスメソッドexceed?を定義。

- views/products/indexとshowに出資の達成状況がわかる表示を追加。

## 現状
想定通り動作しております。