### PR TITLE
運営管理者の追加

### DIFF
--- a/app/assets/javascripts/administer/investments.coffee
+++ b/app/assets/javascripts/administer/investments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/administer/investments.scss
+++ b/app/assets/stylesheets/administer/investments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the administer/investments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/administer/application_controller.rb
+++ b/app/controllers/administer/application_controller.rb
@@ -1,0 +1,2 @@
+class Administer::ApplicationController < ApplicationController
+end

--- a/app/controllers/administer/investments_controller.rb
+++ b/app/controllers/administer/investments_controller.rb
@@ -1,9 +1,14 @@
 class Administer::InvestmentsController < Administer::ApplicationController
+  before_action :login_administer
+
   def index
-    if current_user.administer? 
-      @investments = Investment.all
-    else
-      redirect_to root_path
-    end
+    @investments = Investment.all
   end
+
+  private
+    def login_administer
+      unless current_user.administer? 
+        return redirect_to root_path
+      end
+    end
 end

--- a/app/controllers/administer/investments_controller.rb
+++ b/app/controllers/administer/investments_controller.rb
@@ -1,0 +1,9 @@
+class Administer::InvestmentsController < Administer::ApplicationController
+  def index
+    if current_user.administer? 
+      @investments = Investment.all
+    else
+      redirect_to root_path
+    end
+  end
+end

--- a/app/helpers/administer/investments_helper.rb
+++ b/app/helpers/administer/investments_helper.rb
@@ -1,0 +1,2 @@
+module Administer::InvestmentsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,6 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_products, through: :likes, source: :product
   
+  enum role: [:general, :administer]
+
 end

--- a/app/views/administer/investments/index.html.erb
+++ b/app/views/administer/investments/index.html.erb
@@ -1,0 +1,24 @@
+<p id="notice"><%= notice %></p>
+
+<h1>出資一覧</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>プロダクト名</th>
+      <th>企画者</th>
+      <th>出資金額</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @investments.each do |investment| %>
+      <tr>
+      <td><%= link_to investment.product.title, product_path(investment.product.id) %></td>
+      <td><%= link_to investment.product.user.name, user_path(investment.product.user.id) %>さん</td>
+      <td><%= investment.price %></td>
+      </tr>
+    <% end %>
+  </tbody>
+
+</table>

--- a/app/views/investments/create.html.erb
+++ b/app/views/investments/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Investments#create</h1>
-<p>Find me in app/views/investments/create.html.erb</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,6 +3,9 @@
   <li><%= link_to "みんなのプロダクトを見る", products_path %></li> <!-- 他人の商材 -->
   <li><%= link_to "マイプロダクト", admin_products_path %></li> <!-- 自分の商材 -->
   <li><%= link_to "出資したプロダクト", product_investments_path(current_user.id) %></li> <!-- 自分が出資した商材一覧 -->
+  <% if current_user.administer? %>
+    <li><%= link_to "全ユーザーの出資状況", administer_investments_path %></li> <!-- 全ユーザーの出資状況一覧 -->
+  <% end %>
   <li><%= link_to "プロダクトを作る", new_admin_product_path %></li>
   <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete%></li>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
     resources :products
   end
 
+  namespace :administer do
+    get 'investments', to: 'investments#index'
+  end
+
   root "top#index"
 
 end

--- a/db/migrate/20190416114321_add_role_to_users.rb
+++ b/db/migrate/20190416114321_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_16_065341) do
+ActiveRecord::Schema.define(version: 2019_04_16_114321) do
 
   create_table "investments", force: :cascade do |t|
     t.integer "price"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_03_16_065341) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/administer/investments_controller_test.rb
+++ b/test/controllers/administer/investments_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class Administer::InvestmentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get administer_investments_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
## Issue
#15

## 内容
運営管理者の追加及び全ユーザーの取引管理画面を追加しました。


- 運営管理者の概念を追加
	- userテーブルにroleカラムを追加。
	- user.rbにenumが0の場合general(一般ユーザー)、1の場合administer(運営権限を持ったユーザー)と定義。
	- 今後ユーザーを登録した際や既存のユーザーはroleカラムのdefaultをgeneralにするため、マイグレーションファイルにdefault: 0と設定。


- 運営権限変更
rails cで
```
user = User.find(2)
user.update_attributes(role: 1)
```
としてadministerを設定。


- 運営権限ページの作成
	- namespaceを使用し、ルーティングを設定。
	- adiminister直下にInvestmentsControllerを作るためのクラスの継承を行う。
	- administer/investments_controller.rbのindexアクションでadministerかどうか判別。
- viewの作成
	- ヘッダーに管理者ページのリンクを作成。administerの場合は管理者ページのリンクが表示される。

## 確認内容
管理者のみ管理者画面を確認でき、期待通り動作しています。