### PR TITLE
CatecoryのCRUDを作成

### DIFF
--- a/app/assets/javascripts/categories.coffee
+++ b/app/assets/javascripts/categories.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/administer/categories_controller.rb
+++ b/app/controllers/administer/categories_controller.rb
@@ -1,0 +1,77 @@
+class Administer::CategoriesController < Administer::ApplicationController
+  before_action :set_category, only: [:show, :edit, :update, :destroy]
+  before_action :login_administer
+
+  def index
+    @categories = Category.all
+  end
+
+
+  def show
+  end
+
+
+  def new
+    @category = Category.new
+  end
+
+
+  def edit
+  end
+
+
+  def create
+    @category = Category.new(category_params)
+
+    respond_to do |format|
+      if @category.save
+        format.html { redirect_to [:administer, @category], notice: 'Category was successfully created.' }
+        format.json { render :show, status: :created, location: [:administer, @category] }
+      else
+        format.html { render :new }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+
+
+  def update
+    respond_to do |format|
+      if @category.update(category_params)
+        format.html { redirect_to [:administer, @category], notice: 'Category was successfully updated.' }
+        format.json { render :show, status: :ok, location: [:administer, @category] }
+      else
+        format.html { render :edit }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+
+
+  def destroy
+    @category.destroy
+    respond_to do |format|
+      format.html { redirect_to administer_categories_url, notice: 'Category was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    def set_category
+      @category = Category.find(params[:id])
+    end
+
+
+    def category_params
+      params.require(:category).permit(:name)
+    end
+
+    def login_administer
+      unless current_user.administer? 
+        return redirect_to root_path
+      end
+    end
+end

--- a/app/controllers/administer/categories_controller.rb
+++ b/app/controllers/administer/categories_controller.rb
@@ -69,7 +69,7 @@ class Administer::CategoriesController < Administer::ApplicationController
       params.require(:category).permit(:name)
     end
 
-    def login_administer
+    def verify_administer
       unless current_user.administer? 
         return redirect_to root_path
       end

--- a/app/controllers/administer/investments_controller.rb
+++ b/app/controllers/administer/investments_controller.rb
@@ -6,7 +6,7 @@ class Administer::InvestmentsController < Administer::ApplicationController
   end
 
   private
-    def login_administer
+    def verify_administer
       unless current_user.administer? 
         return redirect_to root_path
       end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/views/administer/categories/_category.json.jbuilder
+++ b/app/views/administer/categories/_category.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! category, :id, :name, :created_at, :updated_at
+json.url category_url(category, format: :json)

--- a/app/views/administer/categories/_form.html.erb
+++ b/app/views/administer/categories/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: [:administer, category], local: true) do |form| %>
+  <% if category.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(category.errors.count, "error") %> prohibited this category from being saved:</h2>
+
+      <ul>
+      <% category.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/administer/categories/edit.html.erb
+++ b/app/views/administer/categories/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Category</h1>
+
+<%= render 'form', category: @category %>
+
+<%= link_to 'Show', [:administer, @category] %> |
+<%= link_to 'Back', administer_categories_path %>

--- a/app/views/administer/categories/index.html.erb
+++ b/app/views/administer/categories/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Categories</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @categories.each do |category| %>
+      <tr>
+        <td><%= category.name %></td>
+        <td><%= link_to 'Show', [:administer, category] %></td>
+        <td><%= link_to 'Edit', edit_administer_category_path(category) %></td>
+        <td><%= link_to 'Destroy', [:administer, category], method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Category', new_administer_category_path %>

--- a/app/views/administer/categories/index.json.jbuilder
+++ b/app/views/administer/categories/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @categories, partial: 'categories/category', as: :category

--- a/app/views/administer/categories/new.html.erb
+++ b/app/views/administer/categories/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Category</h1>
+
+<%= render 'form', category: @category %>
+
+<%= link_to 'Back', administer_categories_path %>

--- a/app/views/administer/categories/show.html.erb
+++ b/app/views/administer/categories/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @category.name %>
+</p>
+
+<%= link_to 'Edit', edit_administer_category_path(@category) %> |
+<%= link_to 'Back', administer_categories_path %>

--- a/app/views/administer/categories/show.json.jbuilder
+++ b/app/views/administer/categories/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "categories/category", category: @category

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,11 +3,16 @@
   <li><%= link_to "みんなのプロダクトを見る", products_path %></li> <!-- 他人の商材 -->
   <li><%= link_to "マイプロダクト", admin_products_path %></li> <!-- 自分の商材 -->
   <li><%= link_to "出資したプロダクト", product_investments_path(current_user.id) %></li> <!-- 自分が出資した商材一覧 -->
-  <% if current_user.administer? %>
-    <li><%= link_to "全ユーザーの出資状況", administer_investments_path %></li> <!-- 全ユーザーの出資状況一覧 -->
-  <% end %>
   <li><%= link_to "プロダクトを作る", new_admin_product_path %></li>
   <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete%></li>
+    <% if current_user.administer? %>
+      <ul>
+      <p>管理者</p>
+      <li><%= link_to "全ユーザーの出資状況", administer_investments_path %></li> <!-- 全ユーザーの出資状況一覧 -->
+      <li><%= link_to "カテゴリーの作成", administer_categories_path %></li>
+      </ul>
+    <% end %>
+
 <% else %>
   <li><%= link_to "トップ", root_path %></li>
   <li><%= link_to "プロダクトを見る", products_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
   namespace :administer do
     get 'investments', to: 'investments#index'
+    resources :categories
   end
 
   root "top#index"

--- a/db/migrate/20190419022337_create_categories.rb
+++ b/db/migrate/20190419022337_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_16_114321) do
+ActiveRecord::Schema.define(version: 2019_04_19_022337) do
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "investments", force: :cascade do |t|
     t.integer "price"

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @category = categories(:one)
+  end
+
+  test "should get index" do
+    get categories_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_category_url
+    assert_response :success
+  end
+
+  test "should create category" do
+    assert_difference('Category.count') do
+      post categories_url, params: { category: { name: @category.name } }
+    end
+
+    assert_redirected_to category_url(Category.last)
+  end
+
+  test "should show category" do
+    get category_url(@category)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_category_url(@category)
+    assert_response :success
+  end
+
+  test "should update category" do
+    patch category_url(@category), params: { category: { name: @category.name } }
+    assert_redirected_to category_url(@category)
+  end
+
+  test "should destroy category" do
+    assert_difference('Category.count', -1) do
+      delete category_url(@category)
+    end
+
+    assert_redirected_to categories_url
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/categories_test.rb
+++ b/test/system/categories_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class CategoriesTest < ApplicationSystemTestCase
+  setup do
+    @category = categories(:one)
+  end
+
+  test "visiting the index" do
+    visit categories_url
+    assert_selector "h1", text: "Categories"
+  end
+
+  test "creating a Category" do
+    visit categories_url
+    click_on "New Category"
+
+    fill_in "Name", with: @category.name
+    click_on "Create Category"
+
+    assert_text "Category was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Category" do
+    visit categories_url
+    click_on "Edit", match: :first
+
+    fill_in "Name", with: @category.name
+    click_on "Update Category"
+
+    assert_text "Category was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Category" do
+    visit categories_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Category was successfully destroyed"
+  end
+end


### PR DESCRIPTION
## Issue

#17



## 内容

administer直下にCategoryのCRUDが行えるページを追加しました。



- scaffoldでCategoryのCRUDを実装。

- Administer::ApplicationControllerを継承したCategoriesControllerを作成。


## 確認内容

運営管理者のみカテゴリーのCRUDができる状況です。