### PR TITLE
メッセージ機能の作成

### DIFF
--- a/app/assets/javascripts/message_groups.coffee
+++ b/app/assets/javascripts/message_groups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/messages.coffee
+++ b/app/assets/javascripts/messages.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/message_groups.scss
+++ b/app/assets/stylesheets/message_groups.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the message_groups controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the messages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/message_groups_controller.rb
+++ b/app/controllers/message_groups_controller.rb
@@ -1,0 +1,47 @@
+class MessageGroupsController < ApplicationController
+  before_action :set_message_group, only: [:show, :message_create]
+
+  def index
+    @message_groups = current_user.message_groups.all
+  end
+
+
+  def new
+    @message_group = MessageGroup.new
+  end
+
+  def create
+    @message_group = MessageGroup.new(message_group_params)
+    @message_group.user_message_groups.new(user_id: current_user.id)
+    @message_group.save
+    redirect_to message_group_path(@message_group)
+  end
+
+  def show
+    @message = @message_group.messages.new
+    @messages = Message.where(message_group_id: @message_group).newer
+  end
+
+  def message_create
+    @message = @message_group.messages.new(message_params)
+    @message.sender_id = current_user.id
+    @message.save
+    redirect_back(fallback_location: root_path)
+  end
+
+
+  private
+
+    def set_message_group
+      @message_group = MessageGroup.find(params[:id])
+    end
+
+    def message_group_params
+      params.require(:message_group).permit(:name, :user_ids)
+    end
+
+    def message_params
+      params.require(:message).permit(:comment)
+      # .merge(sender_id: current_user.id)
+    end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,2 @@
+class MessagesController < ApplicationController
+end

--- a/app/helpers/message_groups_helper.rb
+++ b/app/helpers/message_groups_helper.rb
@@ -1,0 +1,2 @@
+module MessageGroupsHelper
+end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,2 @@
+module MessagesHelper
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  validates :comment, presence: true
+  belongs_to :message_group
+  belongs_to :sender, class_name: 'User', foreign_key: 'sender_id'
+
+  scope :newer, -> { order(id: :desc) }
+end

--- a/app/models/message_group.rb
+++ b/app/models/message_group.rb
@@ -1,0 +1,6 @@
+class MessageGroup < ApplicationRecord
+  validates :name, presence: true
+  has_many :messages
+  has_many :user_message_groups
+  has_many :users, through: :user_message_groups
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,7 @@ class User < ApplicationRecord
   has_many :categories, through: :watchings
   enum role: [:general, :administer]
 
+  has_many :user_message_groups
+  has_many :message_groups, through: :user_message_groups
+
 end

--- a/app/models/user_message_group.rb
+++ b/app/models/user_message_group.rb
@@ -1,0 +1,4 @@
+class UserMessageGroup < ApplicationRecord
+  belongs_to :user
+  belongs_to :message_group
+end

--- a/app/views/investments/index.html.erb
+++ b/app/views/investments/index.html.erb
@@ -22,3 +22,5 @@
   </tbody>
 
 </table>
+<br>
+<%= link_to "企画者と連絡を取る", new_message_group_path %>

--- a/app/views/message_groups/index.html.erb
+++ b/app/views/message_groups/index.html.erb
@@ -1,0 +1,6 @@
+<h3>グループ</h3>
+<% @message_groups.each do |message_group| %>
+    <p><%= link_to message_group.name, message_group_path(message_group.id) %></p>
+<% end %>
+<br>
+<%= link_to "グループを作成する", new_message_group_path %>

--- a/app/views/message_groups/new.html.erb
+++ b/app/views/message_groups/new.html.erb
@@ -1,0 +1,21 @@
+<h4>プロダクトの企画者とメッセージをする</h4>
+<p>メッセージしたいプロダクトの企画者を選択してください。<br>
+セレクトボックスにはあなたが出資したプロダクトの企画者のみ選択できます。<br>
+グループ名は自由に作成してください。
+</p>
+
+<%= form_with model: @message_group do |f| %>
+
+  <div class="filed">
+    <%= f.label :ユーザーを選択してください %>
+    <%= f.collection_select :user_ids, User.joins(products: :investments).where(investments: {user_id: current_user.id}).distinct, :id, :name, { include_blank: '選択してください'}  %>
+  </div>
+
+  <div class="field">
+    <%= f.label :グループ名 %>
+    <%= f.text_field :name %>
+  </div>
+  <div class="actions">  
+    <%= f.submit "グループを作成する" %>
+  </div>
+<% end %>

--- a/app/views/message_groups/show.html.erb
+++ b/app/views/message_groups/show.html.erb
@@ -1,0 +1,28 @@
+<h4><%= @message_group.name %></h4>
+
+<%= form_with model: @message, url: message_create_message_group_path do |f| %>
+  <div class="field">
+    <%= f.text_field :comment %>
+  </div>
+  <div class="actions">  
+    <%= f.submit "メッセージを送る" %>
+  </div>
+<% end %>
+
+<% @messages.each do |message| %>
+  <% if message.sender_id == current_user.id %>
+    <p>
+      <%= message.comment %>
+      <%= link_to message.sender.name, user_path(message.sender_id)%>
+      <%= message.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+    </p>
+  <% else %>
+    <p>
+      <strong>
+        <%= message.comment %>
+        <%= link_to message.sender.name, user_path(message.sender_id)%>
+        <%= message.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+      </strong>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>プロダクト</h1>
+<h3>プロダクト</h3>
 
 <table>
   <thead>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,9 @@
   <li><%= link_to "出資したプロダクト", product_investments_path(current_user.id) %></li> <!-- 自分が出資した商材一覧 -->
   <li><%= link_to "プロダクトを作る", new_admin_product_path %></li>
   <li><%= link_to "ユーザー一覧", users_path %></li>
+  <li><%= link_to "メッセージ一覧", message_groups_path %></li>
   <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete%></li>
+
     <% if current_user.administer? %>
       <ul>
       <p>管理者</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,8 @@ module Crowdfunding
         helper_specs: false,
         routing_specs: false
     end
+
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local 
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:comment_time] = "%Y年%m月%d日 %H時%M分"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,10 @@ Rails.application.routes.draw do
     resources :categories
   end
 
+  resources :message_groups do
+    post 'message_create', on: :member
+  end
+
   root "top#index"
 
 end

--- a/db/migrate/20190523022728_create_message_groups.rb
+++ b/db/migrate/20190523022728_create_message_groups.rb
@@ -1,0 +1,9 @@
+class CreateMessageGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :message_groups do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190523023417_create_user_message_groups.rb
+++ b/db/migrate/20190523023417_create_user_message_groups.rb
@@ -1,0 +1,10 @@
+class CreateUserMessageGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_message_groups do |t|
+      t.references :user, foreign_key: true
+      t.references :message_group, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190523023647_create_messages.rb
+++ b/db/migrate/20190523023647_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :messages do |t|
+      t.string :comment
+      t.references :message_group, foreign_key: true, null: false
+      t.references :sender, foreign_key: { to_table: :users }, null: false
+
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_08_125906) do
+ActiveRecord::Schema.define(version: 2019_05_23_023647) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -35,6 +35,22 @@ ActiveRecord::Schema.define(version: 2019_05_08_125906) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "message_groups", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.string "comment"
+    t.integer "message_group_id", null: false
+    t.integer "sender_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_group_id"], name: "index_messages_on_message_group_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
+  end
+
   create_table "product_categories", force: :cascade do |t|
     t.integer "product_id"
     t.integer "category_id"
@@ -52,6 +68,15 @@ ActiveRecord::Schema.define(version: 2019_05_08_125906) do
     t.datetime "updated_at", null: false
     t.integer "price"
     t.string "thumbnail"
+  end
+
+  create_table "user_message_groups", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "message_group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_group_id"], name: "index_user_message_groups_on_message_group_id"
+    t.index ["user_id"], name: "index_user_message_groups_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/message_groups_controller_spec.rb
+++ b/spec/controllers/message_groups_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MessageGroupsController, type: :controller do
+
+end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MessagesController, type: :controller do
+
+end

--- a/spec/factories/message_groups.rb
+++ b/spec/factories/message_groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :message_group do
+    
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :message do
+    
+  end
+end

--- a/spec/factories/user_message_groups.rb
+++ b/spec/factories/user_message_groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_message_group do
+    
+  end
+end

--- a/spec/models/message_group_spec.rb
+++ b/spec/models/message_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MessageGroup, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_message_group_spec.rb
+++ b/spec/models/user_message_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserMessageGroup, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Issue
#30 

# 内容

出品者とメッセージできる機能を作成しました。
- message_groups、messages、user_message_groups(中間テーブル)の３つのテーブルを作成。
  - messagesテーブルのカラムsenderはマイグレーションファイルで参照先を指定する。ここではforeign_key: { to_table: :users }となる。
  - Messageモデルで以下のように定義する。
  ```ruby
  belongs_to :sender, class_name: 'User', foreign_key: 'sender_id'
  ```
- MessageGroups#newはグループを作成するページ、MessageGroups#showはメッセージをやり取りするページとする。
  - MessageGroups#createでログインしているユーザーとセレクトボックスで選択したユーザーの二つの中間テーブル(user_message_groups)が作成される。
  - MessageGroups#message_createにメッセージのやり取りを作成する機能を作る。
    - ルーティングに自前のアクションを追加する。
     ```ruby
     post 'message_create', on: :member
     ```
  - MessageGroups#newはInvestments#indexからの遷移。
  - 出資者は自ら出資したプロダクトのオーナーとしかやり取りできない。
    MessageGroups#newのセレクトボックスに以下のように指定し出資できるユーザーを絞り込む。
    ```ruby
    User.joins(products: :investments).where(investments: {user_id: current_user.id}).distinct
    ```
# 確認内容
想定通り動作しています。